### PR TITLE
Run GitHub Actions on push to master and PR

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -1,6 +1,11 @@
 name: "CodeQL"
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/compile.yml
+++ b/.github/workflows/compile.yml
@@ -1,5 +1,11 @@
 name: compile
-on: push
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,5 +1,11 @@
 name: docker-compose-action-CI
-on: push
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+  
 jobs:
   test:
     runs-on: ubuntu-latest

--- a/.github/workflows/rubocop-analysis.yml
+++ b/.github/workflows/rubocop-analysis.yml
@@ -1,6 +1,11 @@
 name: rubocop-code-scan
 
-on: push
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+
 jobs:
   rubocop:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
  Have any questions? Open a new issue. :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
When pushing to a branch that's not master, master will run again. This quickly fixes it, but I'm going to keep updating the workflows.

GitHub has an annoying way of restricting users to only be able update workflows directly in GitHub.