### PR TITLE
Update ruby to version 2.6 to fix rubocop-ast error

### DIFF
--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -22,7 +22,7 @@ jobs:
         ruby-version: 2.5
 
     - name: Install rubocop
-      run: gem install rubocop -v '~> 1.9.1'
+      run: gem install rubocop # -v '~> 1.9.1'
     - name: Check Rubocop
       run: rubocop
 

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -19,10 +19,10 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.5
+        ruby-version: 2.6
 
     - name: Install rubocop
-      run: gem install rubocop # -v '~> 1.9.1'
+      run: gem install rubocop -v '~> 1.9.1'
     - name: Check Rubocop
       run: rubocop
 


### PR DESCRIPTION
<!--
  Have any questions? Open a new issue. :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

GitHub Action failed by not finding compatible versions of `rubocop-ast` compatible with `ruby 2.5`. Fixed by updating ruby to version `2.6`.
