### PR TITLE
Pre-commit and GitHub Action updates

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -13,8 +13,5 @@ jobs:
       - uses: actions/checkout@v2
       - name: Run make
         run: make
-      - run: sudo apt install clang-format-10
-      - name: Run clang-format check
-        run: make cformat_check
       - name: Clean files
         run: make clean

--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.6.x' ]
+        python-version: [ '3.8.x' ]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,17 +2,20 @@
 # More will be added later
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v3.2.0
+    rev: v4.3.0
     hooks:
-    -   id: trailing-whitespace
-    -   id: end-of-file-fixer
-    -   id: check-yaml
     -   id: check-added-large-files
+    -   id: check-executables-have-shebangs
+    -   id: check-yaml
+    -   id: end-of-file-fixer
+    -   id: mixed-line-ending
+    -   id: requirements-txt-fixer
+    -   id: trailing-whitespace
 -   repo: https://github.com/PyCQA/flake8
     rev: 4.0.1
     hooks:
     -   id: flake8
 -   repo: https://github.com/chriskuehl/puppet-pre-commit-hooks.git
-    rev: v2.1.0
+    rev: v2.2.0
     hooks:
     -   id: ruby-validate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,3 +19,7 @@ repos:
     rev: v2.2.0
     hooks:
     -   id: ruby-validate
+-   repo: https://github.com/pocc/pre-commit-hooks
+    rev: v1.3.5
+    hooks:
+    -   id: clang-format

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,6 @@
 CC = gcc
 CFLAGS = -Wall -g
 FORMATTER = clang-format-10
-FORMATTER_FLAGS = --dry-run -Werror
 
 # Since the codes are not in the same directory
 SRCS = $(wildcard sys/file_folder/*.c) $(wildcard sys/info/*.c) $(wildcard sys/proc/*.c)
@@ -20,7 +19,3 @@ clean:
 
 cformat:
 	$(FORMATTER) -i $(SRCS) $(HEADERS)
-
-# This is to check if user needs to compile code
-cformat_check:
-	$(FORMATTER) $(FORMATTER_FLAGS) $(SRCS) $(HEADERS)


### PR DESCRIPTION
<!--
  Have any questions? Open a new issue. :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adds `clang_format` to `pre-commit` which means we don't need to have a `cformat_check` in the GitHub Action or Makefile.