### PR TITLE
Add option to run sphinx locally in docs target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,13 @@ docs:
 	./scripts/copy_content
 	./scripts/build_sphinx
 
+ifdef run
+	@echo "Running sphinx locally..."
+	./scripts/run_sphinx_locally
+else
+	@echo "To run sphinx locally use run=1 with docs."
+endif
+
 .PHONY: docs
 
 alias:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you don't want to install the whole tool. You can download a script or script
 
 > Big part of the reason why I created this project is to learn, that's why I have used different programming languages when I could've just used one.
 
-#### Usage:
+## Usage:
 
 ```bash
 git clone https://github.com/endormi/tilux.git
@@ -126,7 +126,21 @@ tilux
 
 > However `tilux` is not required to run scripts individually. [See here](GUIDE.md#run-from-any-folder).
 
-To see the commands to use, how to run from any folder, how to run using Docker and how to download a specific script, click [here](GUIDE.md).
+To see the commands to use, how to run from any folder, how to run using Docker and how to download a script or scripts, click [here](GUIDE.md).
+
+Run `docs` locally:
+
+> `make docs` builds the `docs` and `run=1` runs `docs` locally.
+
+```bash
+make docs run=1
+```
+
+Run `man pages`:
+
+```bash
+./scripts/groff
+```
 
 To use `Pyca` you need to first generate key:
 

--- a/docs/source/installation.md
+++ b/docs/source/installation.md
@@ -97,3 +97,19 @@ tilux
 ```
 
 **NOTE**: the command will CD into the `tilux` folder location.
+
+## Running docs
+
+Run `docs` locally:
+
+> `make docs` builds the `docs` and `run=1` runs `docs` locally.
+
+```
+make docs run=1
+```
+
+Run `man pages`:
+
+```
+./scripts/groff
+```


### PR DESCRIPTION
<!--
  Have any questions? Open a new issue. :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

By adding `run=1` along with `make docs` you will run sphinx locally. Also adds instructions for running man pages.