### PR TITLE
Add path to make workflow

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -8,11 +8,13 @@ on:
       - 'docs/**'
       - 'sys/**/**.c'
       - 'sys/**/**.h'
+      - 'tools/**.h'
   pull_request:
     paths:
       - 'docs/**'
       - 'sys/**/**.c'
       - 'sys/**/**.h'
+      - 'tools/**.h'
 
 jobs:
   test:


### PR DESCRIPTION
<!--
  Have any questions? Open a new issue. :)
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->

Adds `tools/` path to make workflow. Make should also run when tools' header files are updated.
